### PR TITLE
Add vigenere cipher operation

### DIFF
--- a/packages/app-web/src/slices/directory/index.ts
+++ b/packages/app-web/src/slices/directory/index.ts
@@ -223,6 +223,88 @@ const defaultDirectoryState: DirectoryState = {
     },
     {
       type: 'operation',
+      name: '@ciphereditor/extension-essentials/vigenere-cipher',
+      label: 'Vigenère cipher',
+      description: 'Method in which each letter in a text is replaced by a letter a number of places down the alphabet dependent on a provided key.',
+      extensionUrl: 'https://cdn.ciphereditor.com/extensions/@ciphereditor/extension-essentials/1.0.0-alpha/extension.js?v=1',
+      keywords: ['substitution cipher', 'shift', 'vigenere', 'key', 'beaufort', 'trithemius'],
+      controls: [
+        {
+          name: 'plaintext',
+          initialValue: 'The quick brown fox jumps over the lazy dog.',
+          types: ['text']
+        },
+        {
+          name: 'variant',
+          initialValue: 'vigenere',
+          types: ['text'],
+          choices: [
+            {
+              value: 'vigenere',
+              label: 'Vigenère cipher'
+            },
+            {
+              value: 'beaufort',
+              label: 'Beaufort cipher'
+            },
+            {
+              value: 'variantBeaufort',
+              label: 'Variant Beaufort cipher'
+            },
+            {
+              value: 'trithemius',
+              label: 'Trithemius cipher'
+            }
+          ]
+        },
+        {
+          name: 'key',
+          initialValue: 'ciphereditor',
+          types: ['text']
+        },
+        {
+          name: 'keyMode',
+          initialValue: 'repeat',
+          types: ['text'],
+          choices: [
+            { value: 'repeat', label: 'Repeat' },
+            { value: 'autoKey', label: 'Auto-key' }
+          ]
+        },
+        {
+          name: 'alphabet',
+          initialValue: 'abcdefghijklmnopqrstuvwxyz',
+          types: ['text'],
+          choices: [
+            {
+              value: 'abcdefghijklmnopqrstuvwxyz',
+              label: 'Latin alphabet (a-z)'
+            },
+            {
+              value: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+              label: 'Uppercase Latin alphabet (A-Z)'
+            },
+            {
+              value: 'αβγδεζηθικλμνξοπρστυφχψω',
+              label: 'Greek alphabet (α-ω)'
+            },
+            {
+              value: 'ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡΣΤΥΦΧΨΩ',
+              label: 'Uppercase Greek alphabet (Α-Ω)'
+            }
+          ],
+          enforceChoices: false
+        },
+        {
+          name: 'ciphertext',
+          initialValue: 'Vpt xyzgn jkcnp nde nlqsa hjvt bwl prdb lhu.',
+          types: ['text'],
+          order: 1000
+        }
+      ]
+    },
+    {
+      type: 'operation',
       name: '@ciphereditor/extension-essentials/concatenate',
       extensionUrl: 'https://cdn.ciphereditor.com/extensions/@ciphereditor/extension-essentials/1.0.0-alpha/extension.js?v=1',
       label: 'Concatenate',

--- a/packages/extension-essentials/src/index.ts
+++ b/packages/extension-essentials/src/index.ts
@@ -9,6 +9,7 @@ import logicalAnd from './logical-and'
 import logicalNot from './logical-not'
 import logicalOr from './logical-or'
 import rot13 from './rot13'
+import vigenereCipher from './vigenere-cipher'
 import wordCounter from './word-counter'
 import { ExtensionActivateExport } from '@ciphereditor/types'
 
@@ -23,5 +24,6 @@ export const activate: ExtensionActivateExport = (context) => [
   logicalNot,
   logicalOr,
   rot13,
+  vigenereCipher,
   wordCounter
 ]

--- a/packages/extension-essentials/src/vigenere-cipher.ts
+++ b/packages/extension-essentials/src/vigenere-cipher.ts
@@ -1,0 +1,225 @@
+import { Contribution, NamedControlChange, OperationExecuteExport, OperationIssue } from '@ciphereditor/types'
+import { alphabetTextChoices } from './shared/choices'
+import { hasUniqueElements } from './lib/array'
+import { mod } from './lib/math'
+import { stringFromUnicodeCodePoints, stringToUnicodeCodePoints } from './lib/string'
+
+const contribution: Contribution = {
+  type: 'operation',
+  name: '@ciphereditor/extension-essentials/vigenere-cipher',
+  label: 'Vigenère cipher',
+  description: 'Method in which each letter in a text is replaced by a letter a number of places down the alphabet dependent on a provided key.',
+  url: 'https://ciphereditor.com/operations/vigenere-cipher',
+  keywords: ['substitution cipher', 'shift', 'vigenere', 'key', 'beaufort', 'trithemius'],
+  controls: [
+    {
+      name: 'plaintext',
+      initialValue: 'The quick brown fox jumps over the lazy dog.',
+      types: ['text']
+    },
+    {
+      name: 'variant',
+      initialValue: 'vigenere',
+      types: ['text'],
+      choices: [
+        {
+          value: 'vigenere',
+          label: 'Vigenère cipher'
+        },
+        {
+          value: 'beaufort',
+          label: 'Beaufort cipher'
+        },
+        {
+          value: 'variantBeaufort',
+          label: 'Variant Beaufort cipher'
+        },
+        {
+          value: 'trithemius',
+          label: 'Trithemius cipher'
+        }
+      ]
+    },
+    {
+      name: 'key',
+      initialValue: 'ciphereditor',
+      types: ['text']
+    },
+    {
+      name: 'keyMode',
+      initialValue: 'repeat',
+      types: ['text'],
+      choices: [
+        { value: 'repeat', label: 'Repeat' },
+        { value: 'autoKey', label: 'Auto-key' }
+      ]
+    },
+    {
+      name: 'alphabet',
+      initialValue: 'abcdefghijklmnopqrstuvwxyz',
+      types: ['text'],
+      choices: alphabetTextChoices,
+      enforceChoices: false
+    },
+    {
+      name: 'ciphertext',
+      initialValue: 'Vpt xyzgn jkcnp nde nlqsa hjvt bwl prdb lhu.',
+      types: ['text'],
+      order: 1000
+    }
+  ]
+}
+
+const execute: OperationExecuteExport = (request) => {
+  const { values, controlPriorities } = request
+  const changes: NamedControlChange[] = []
+  const issues: OperationIssue[] = []
+
+  const forward = controlPriorities.indexOf('plaintext') < controlPriorities.indexOf('ciphertext')
+  const inputControl = forward ? 'plaintext' : 'ciphertext'
+
+  const input = values[inputControl].data as string
+  const inputCodePoints = stringToUnicodeCodePoints(input)
+
+  // Prepare alphabet
+  const alphabet = (values.alphabet.data as string).toLowerCase()
+  const alphabetCodePoints = stringToUnicodeCodePoints(alphabet)
+
+  // Validate alphabet
+  if (alphabetCodePoints.length <= 1) {
+    return {
+      type: 'error',
+      controlName: 'alphabet',
+      message: 'The alphabet must have a size of 2 characters or more'
+    }
+  }
+
+  if (!hasUniqueElements(alphabetCodePoints)) {
+    return {
+      type: 'error',
+      controlName: 'alphabet',
+      message: 'The alphabet must not contain duplicate characters'
+    }
+  }
+
+  // Prepare uppercase alphabet
+  const uppercaseAlphabetCodePoints = stringToUnicodeCodePoints(alphabet.toUpperCase())
+
+  // Prepare key
+  let keyMode = values.keyMode.data as string
+  let key = (values.key.data as string).toLowerCase()
+  // Correct for variants
+  const variant = values.variant.data as string
+  if (variant === 'trithemius') {
+    // TODO: Disable the key and key mode controls.
+    key = alphabet
+    keyMode = 'repeat'
+  }
+  const keyCodePoints = stringToUnicodeCodePoints(key)
+
+  // Validate key
+  if (keyCodePoints.length === 0) {
+    return {
+      type: 'error',
+      controlName: 'key',
+      message: 'The key must have a size of 1 character or more'
+    }
+  }
+
+  if (!keyCodePoints.every(codePoint => alphabetCodePoints.includes(codePoint))) {
+    return {
+      type: 'error',
+      controlName: 'key',
+      message: 'The key must only contain characters from the alphabet'
+    }
+  }
+
+  const m = alphabetCodePoints.length
+  const n = inputCodePoints.length
+  const result = new Array(n)
+
+  let codePoint, x, y, uppercase
+  let j = 0
+  let k = 0
+
+  // Go through each character in content
+  for (let i = 0; i < n; i++) {
+    codePoint = inputCodePoints[i]
+
+    // Match alphabet character
+    x = alphabetCodePoints.indexOf(codePoint)
+    uppercase = false
+
+    // Match uppercase alphabet character (depending on case strategy)
+    if (x === -1) {
+      x = uppercaseAlphabetCodePoints.indexOf(codePoint)
+      uppercase = true
+    }
+
+    if (x === -1) {
+      // Character is not in the alphabet
+      result[j++] = codePoint
+    } else {
+      // Shift character depending on variant
+      const keyCodePoint = keyCodePoints[k++]
+      const shift = alphabetCodePoints.indexOf(keyCodePoint)
+      switch (variant) {
+        case 'beaufort':
+          y = shift - x
+          break
+        case 'variantBeaufort':
+          y = forward
+            ? x - shift
+            : x + shift
+          break
+        default:
+          y = forward
+            ? x + shift
+            : x - shift
+      }
+      y = mod(y, m)
+
+      // Translate index to character following the case strategy
+      if (uppercase) {
+        result[j++] = uppercaseAlphabetCodePoints[y]
+      } else {
+        result[j++] = alphabetCodePoints[y]
+      }
+
+      // Extend key according to given method
+      switch (keyMode) {
+        case 'autoKey':
+          // Encoding uses input, decoding uses output
+          keyCodePoints.push(alphabetCodePoints[forward ? x : y])
+          break
+
+        case 'repeat':
+          keyCodePoints.push(keyCodePoint)
+          break
+      }
+    }
+  }
+
+  // Key-index not incremented implies no characters appear in the alphabet
+  if (k === 0) {
+    issues.push({
+      type: 'warn',
+      controlName: inputControl,
+      message: 'None of the characters are part of the alphabet and they all get ignored'
+    })
+  }
+
+  const resultCodePoints = result.slice(0, j)
+  const outputControl = forward ? 'ciphertext' : 'plaintext'
+  const output = stringFromUnicodeCodePoints(resultCodePoints)
+  changes.push({name: outputControl, value: output})
+
+  return { changes: changes, issues: issues }
+}
+
+export default {
+  contribution,
+  body: {
+    execute
+  }
+}


### PR DESCRIPTION
This PR adds the Vigenère cipher operation to the `@ciphereditor/extension-essentials`.  The code is based on the Caesar cipher and [cryptii code][1] for the Vigenère cipher.

Four different variants of the cipher are available, just like Cryptii.
1. Traditional Vigenère cipher: `inputIndex` + `alphabetIndex`,
2. Beaufort cipher: `alphabetIndex` - `inputIndex`,
3. Variant Beaufort cipher: `inputIndex` - `alphabetIndex`,
4. Trithemius cipher: Vigenere with fixed key and key mode.

The code gives an error when the key is empty or contains characters not in the alphabet.  If none of the plain-/ciphertext characters are from the alphabet, it warns the user to avoid confusion.

The Trithemius cipher uses a fixed key and key mode.  Currently, this is not communicated to the user, this can be part of an upcoming update.

<details open>
<summary>
The images below show the difference between key mode “repeat” → `keykey` and “auto-key” → `keymessage`, the cipher variants and the errors & warning.
</summary>

(The first and third image were created before the variants were implemented, hence they lack that control.)

<img height="450" alt="vigenere cipher example" src="https://user-images.githubusercontent.com/33520919/181994784-2a648962-e9b3-4a39-b159-96e44ed0d8bc.png">
<img width="1359" alt="vigenere cipher variants" src="https://user-images.githubusercontent.com/33520919/182002258-34d74e91-bf21-48ce-bf5a-4ddf353d1175.png">
<img width="1190" alt="vigenere cipher errors" src="https://user-images.githubusercontent.com/33520919/181994785-66509c92-e43f-474c-944d-81f549ede729.png">
</details>

I did my best attempt at writing a description for the operation, but I'm unsure if it is easily understandable in its current form.

PS: It was fun to do this, the system feels nice and is self-documenting for the most part. The most obvious place where something could be simplified with less code duplication is already addressed in the backlog as well: https://github.com/wierkstudio/ciphereditor/blob/c722c049cf8ebfcf9b4ffdbe71577135508f459a/packages/app-web/src/slices/directory/index.ts#L6-L7

[1]: https://github.com/cryptii/cryptii/blob/b8f964f926a1a03af016dc8e591811a5c57a6830/src/Encoder/VigenereCipher.js#L111-L196