### PR TITLE
Add link to "Development setup" from root

### DIFF
--- a/packages/app-web/README.md
+++ b/packages/app-web/README.md
@@ -5,4 +5,4 @@ Core web app built on React and Redux Toolkit
 
 ## Development setup
 
-Follow [the instructions](https://github.com/wierkstudio/ciphereditor#development-setup) in the 'Development setup' section in the project root.
+Follow [the instructions](../../README.md#development-setup) in the 'Development setup' section in the project root.

--- a/packages/app-web/README.md
+++ b/packages/app-web/README.md
@@ -5,4 +5,4 @@ Core web app built on React and Redux Toolkit
 
 ## Development setup
 
-Follow the instructions in the 'Development setup' section in the project root.
+Follow [the instructions](https://github.com/wierkstudio/ciphereditor#development-setup) in the 'Development setup' section in the project root.


### PR DESCRIPTION
The README of `app-web`, _Development setup_ does not yet have a link to the project root.
This request serves more as a quality-of-life improvement.