### PR TITLE
Improved keybindings

### DIFF
--- a/packages/app-web/src/hooks/useShortcutHandler.ts
+++ b/packages/app-web/src/hooks/useShortcutHandler.ts
@@ -3,7 +3,7 @@ import { useEffect } from 'react'
 
 /**
  * Register a keydown event handler to the given element and hand over the
- * pressed key combinations using a shortcut notation.
+ * pressed key combinations using a shortcut notation. In other words, listens to keyboard events, compiles the shortcut notation and calls onShortcut
  */
 const useShortcutHandler = (
   element: Window | HTMLElement | null,

--- a/packages/app-web/src/slices/settings/index.ts
+++ b/packages/app-web/src/slices/settings/index.ts
@@ -7,7 +7,7 @@ import {
   removeNodeAction,
   undoAction
 } from '../blueprint'
-import { popModalAction, endWireAction, pushAddModalAction } from '../ui'
+import { popModalAction, endWireAction, toggleAddModalAction } from '../ui'
 import { ReducedMotionPreferenceOption, SettingsState, ThemeOption } from './types'
 
 const defaultSettingsState: SettingsState = {
@@ -27,7 +27,7 @@ const defaultSettingsState: SettingsState = {
     'control+shift+z': redoAction.type,
     'control+y': redoAction.type, // Windows and Linux systems that use Cinnamon as a DE use Ctrl+y for redo. See https://support.apple.com/en-ie/guide/pages/tana7e101d4c/mac, https://support.microsoft.com/en-us/office/undo-redo-or-repeat-an-action-84bdb9bc-4e23-4f06-ba78-f7b893eb2d28, and https://cheatography.com/shakiestnerd/cheat-sheets/linux-mint-cinnamon/
     'escape': [popModalAction.type, endWireAction.type],
-    'meta+k': pushAddModalAction.type
+    'meta+k': toggleAddModalAction.type
     /* eslint-enable quote-props */
   }
 }

--- a/packages/app-web/src/slices/settings/index.ts
+++ b/packages/app-web/src/slices/settings/index.ts
@@ -25,6 +25,7 @@ const defaultSettingsState: SettingsState = {
     'control+z': undoAction.type,
     'shift+meta+z': redoAction.type,
     'control+shift+z': redoAction.type,
+    'control+y': redoAction.type, // Windows and Linux systems that use Cinnamon as a DE use Ctrl+y for redo. See https://support.apple.com/en-ie/guide/pages/tana7e101d4c/mac, https://support.microsoft.com/en-us/office/undo-redo-or-repeat-an-action-84bdb9bc-4e23-4f06-ba78-f7b893eb2d28, and https://cheatography.com/shakiestnerd/cheat-sheets/linux-mint-cinnamon/
     'escape': [popModalAction.type, endWireAction.type]
     /* eslint-enable quote-props */
   }

--- a/packages/app-web/src/slices/settings/index.ts
+++ b/packages/app-web/src/slices/settings/index.ts
@@ -7,7 +7,7 @@ import {
   removeNodeAction,
   undoAction
 } from '../blueprint'
-import { popModalAction, endWireAction } from '../ui'
+import { popModalAction, endWireAction, pushAddModalAction } from '../ui'
 import { ReducedMotionPreferenceOption, SettingsState, ThemeOption } from './types'
 
 const defaultSettingsState: SettingsState = {
@@ -26,7 +26,8 @@ const defaultSettingsState: SettingsState = {
     'shift+meta+z': redoAction.type,
     'control+shift+z': redoAction.type,
     'control+y': redoAction.type, // Windows and Linux systems that use Cinnamon as a DE use Ctrl+y for redo. See https://support.apple.com/en-ie/guide/pages/tana7e101d4c/mac, https://support.microsoft.com/en-us/office/undo-redo-or-repeat-an-action-84bdb9bc-4e23-4f06-ba78-f7b893eb2d28, and https://cheatography.com/shakiestnerd/cheat-sheets/linux-mint-cinnamon/
-    'escape': [popModalAction.type, endWireAction.type]
+    'escape': [popModalAction.type, endWireAction.type],
+    'meta+k': pushAddModalAction.type
     /* eslint-enable quote-props */
   }
 }

--- a/packages/app-web/src/slices/ui/index.ts
+++ b/packages/app-web/src/slices/ui/index.ts
@@ -120,8 +120,8 @@ export const settingsSlice = createSlice({
       pushModal(state, payload.payload)
     },
     toggleAddModalAction: (state, { payload }: PayloadAction<{}>) => {
-      if (state.modalStack.length !== 0 && state.modalStack[state.modalStack.length - 1].type === "add") popModal(state)
-      else pushModal(state, { type: 'add' })
+      if (state.modalStack.length !== 0 && state.modalStack[state.modalStack.length - 1].type === 'add') popModal(state)
+      else if (state.modalStack.length === 0) pushModal(state, { type: 'add' })
     },
     pushReportModalAction: (state, { payload }: PayloadAction<{
       title: string

--- a/packages/app-web/src/slices/ui/index.ts
+++ b/packages/app-web/src/slices/ui/index.ts
@@ -119,6 +119,9 @@ export const settingsSlice = createSlice({
     }>) => {
       pushModal(state, payload.payload)
     },
+    pushAddModalAction: (state, { payload }: PayloadAction<{}>) => {
+      pushModal(state, { type: 'add' })
+    },
     pushReportModalAction: (state, { payload }: PayloadAction<{
       title: string
       description: string
@@ -171,6 +174,7 @@ export const {
   targetWireAction,
   endWireAction,
   pushModalAction,
+  pushAddModalAction,
   pushReportModalAction,
   pushDeadEndModalAction,
   popModalAction,

--- a/packages/app-web/src/slices/ui/index.ts
+++ b/packages/app-web/src/slices/ui/index.ts
@@ -120,7 +120,7 @@ export const settingsSlice = createSlice({
       pushModal(state, payload.payload)
     },
     toggleAddModalAction: (state, { payload }: PayloadAction<{}>) => {
-      if (state.modalStack.length !== 0 && state.modalStack[state.modalStack.length - 1].type === 'add') popModal(state)
+      if (state.modalStack.length === 1 && state.modalStack[0].type === 'add') popModal(state)
       else if (state.modalStack.length === 0) pushModal(state, { type: 'add' })
     },
     pushReportModalAction: (state, { payload }: PayloadAction<{

--- a/packages/app-web/src/slices/ui/index.ts
+++ b/packages/app-web/src/slices/ui/index.ts
@@ -119,8 +119,9 @@ export const settingsSlice = createSlice({
     }>) => {
       pushModal(state, payload.payload)
     },
-    pushAddModalAction: (state, { payload }: PayloadAction<{}>) => {
-      pushModal(state, { type: 'add' })
+    toggleAddModalAction: (state, { payload }: PayloadAction<{}>) => {
+      if (state.modalStack.length !== 0 && state.modalStack[state.modalStack.length - 1].type === "add") popModal(state)
+      else pushModal(state, { type: 'add' })
     },
     pushReportModalAction: (state, { payload }: PayloadAction<{
       title: string
@@ -174,7 +175,7 @@ export const {
   targetWireAction,
   endWireAction,
   pushModalAction,
-  pushAddModalAction,
+  toggleAddModalAction,
   pushReportModalAction,
   pushDeadEndModalAction,
   popModalAction,

--- a/packages/app-web/src/views/app/app.tsx
+++ b/packages/app-web/src/views/app/app.tsx
@@ -68,13 +68,15 @@ export default function AppView (): JSX.Element {
 
   useWindowLoadListener(onAppLoad)
 
-  // Shortcut handler
+  /**
+   * Shortcut handler, receives shortcut notation from a function that calls it, this function looks up the shortcut notation in the shortcut "lookup" table and dispatches the action
+   */
   const onShortcut = useCallback((shortcut: string, event: KeyboardEvent) => {
     const actions = shortcutBindings[shortcut]
     if (actions !== undefined) {
       if (typeof actions === 'string') {
         dispatch({ type: actions, payload: {} })
-      } else {
+      } else { // Allow for also dispatching a whole bunch of actions
         for (const action of actions) {
           dispatch({ type: action, payload: {} })
         }


### PR DESCRIPTION
Adds Ctrl+y keybinding for redo actions, mainly because Windows and the Cinnamon DE (A Linux Desktop Environment aimed at being similar to Windows) use Ctrl+y.

Also adds the Meta+k/Ctrl+k action, inspired from Discord, GitHub and Algolia search to bring up the Add modal.

Next to do is check the platform being run on and disabled/enable certain shortcuts depending on the platform or otherwise there will be conflicting functionality.