### PR TITLE
fix(#14): Autoresize textarea to match the content height

### DIFF
--- a/packages/app-web/src/views/input-text/input-text.scss
+++ b/packages/app-web/src/views/input-text/input-text.scss
@@ -45,7 +45,7 @@
     white-space: pre-wrap;
     word-break: break-word;
     overflow-wrap: anywhere;
-    hyphens: auto;
+    line-break: anywhere;
     line-break: after-white-space;
   }
 

--- a/packages/app-web/src/views/input-text/input-text.scss
+++ b/packages/app-web/src/views/input-text/input-text.scss
@@ -31,6 +31,7 @@
   &__textarea {
     outline: none;
     user-select: auto;
+    overflow: hidden;
   }
 
   &__field::after,
@@ -43,6 +44,9 @@
     @extend %t-value;
     white-space: pre-wrap;
     word-break: break-word;
+    overflow-wrap: anywhere;
+    hyphens: auto;
+    line-break: after-white-space;
   }
 
   &--slim {


### PR DESCRIPTION
Fixes an issue where the textarea auto height behaves differently on firefox 104, safari 16 and chrome 105 on windows