### PR TITLE
Ignore bits that were introduced as padding in `transformUnitSize`

### DIFF
--- a/extensions/essentials/src/binary-slice.ts
+++ b/extensions/essentials/src/binary-slice.ts
@@ -68,7 +68,7 @@ const execute: OperationExecuteExport = (request) => {
 
       // Transform the array of bytes to an array of bits and slice them
       // precisely to create the bit slice
-      const bitSlice = transformUnitSize(byteSlice, 8, 1).slice(
+      const bitSlice = transformUnitSize(byteSlice, 8, 1, true).slice(
         bitSliceArgs.start - byteSliceStart * 8,
         bitSliceArgs.end - byteSliceStart * 8
       )
@@ -76,7 +76,7 @@ const execute: OperationExecuteExport = (request) => {
       // Fill up the first byte with zero bits and turn the bits back into bytes
       const paddingBits = bitSlice.length % 8 > 0 ? 8 - bitSlice.length % 8 : 0
       const sliceBitsPadded = new Array(paddingBits).fill(0).concat(bitSlice)
-      const sliceBytes = transformUnitSize(sliceBitsPadded, 1, 8)
+      const sliceBytes = transformUnitSize(sliceBitsPadded, 8, 1, false)
       slice = new Uint8Array(sliceBytes).buffer
       break
     }

--- a/extensions/essentials/src/binary-to-text.ts
+++ b/extensions/essentials/src/binary-to-text.ts
@@ -149,7 +149,7 @@ const execute: OperationExecuteExport = (request) => {
     ))
 
     // Transform unit size (encode)
-    const encodedUnits = transformUnitSize(units, inUnitSize, outUnitSize)
+    const encodedUnits = transformUnitSize(units, inUnitSize, outUnitSize, true)
     const encodedCodePoints = encodedUnits.map(unit => alphabet[unit])
 
     // Apply padding
@@ -195,7 +195,7 @@ const execute: OperationExecuteExport = (request) => {
     encodedUnits = encodedUnits.slice(0, j)
 
     // Transform unit size (decode)
-    const units = transformUnitSize(encodedUnits, outUnitSize, inUnitSize)
+    const units = transformUnitSize(encodedUnits, inUnitSize, outUnitSize, false)
     const buffer = Uint8Array.from(units).buffer
 
     // Add an issue if foreign characters were encountered


### PR DESCRIPTION
Fixes: #40

Base64 embeds bytes into 6 bit units. It takes two units to properly encode a single byte. If you then decode this, you can conclude that the 4 additional bits contain no information. (Unless the input violates our assumption that it is a base64 encoding.)

You can conclude that if $y = \lceil xs_{input} / s_{output}\rceil$ with x an integer, then $x ≤ \lfloor ys_{output} / s_{input}\rfloor$. This commit checks every added unit if it is the last, and doesn't add the null byte if it is. It might be more efficient to just use the larger array and slice off the null byte when it exists.

It can be impossible to determine a true zero byte from padding if `inputSize < outputSize`, but for binary-to-text that requires an alphabet of more than 256 characters.


<!--
1. Please read and follow the Contributing Guidelines.
2. Describe WHAT your changes do and WHY you are proposing them.
3. Write tests for your changes.
4. Successfully run `npm run test`.
-->
