### PR TITLE
Fix enterProgram shortcut on control nodes

### DIFF
--- a/extensions/essentials/src/binary-slice.ts
+++ b/extensions/essentials/src/binary-slice.ts
@@ -68,7 +68,7 @@ const execute: OperationExecuteExport = (request) => {
 
       // Transform the array of bytes to an array of bits and slice them
       // precisely to create the bit slice
-      const bitSlice = transformUnitSize(byteSlice, 8, 1).slice(
+      const bitSlice = transformUnitSize(byteSlice, 8, 1, true).slice(
         bitSliceArgs.start - byteSliceStart * 8,
         bitSliceArgs.end - byteSliceStart * 8
       )
@@ -76,7 +76,7 @@ const execute: OperationExecuteExport = (request) => {
       // Fill up the first byte with zero bits and turn the bits back into bytes
       const paddingBits = bitSlice.length % 8 > 0 ? 8 - bitSlice.length % 8 : 0
       const sliceBitsPadded = new Array(paddingBits).fill(0).concat(bitSlice)
-      const sliceBytes = transformUnitSize(sliceBitsPadded, 1, 8)
+      const sliceBytes = transformUnitSize(sliceBitsPadded, 8, 1, false)
       slice = new Uint8Array(sliceBytes).buffer
       break
     }

--- a/extensions/essentials/src/binary-to-text.ts
+++ b/extensions/essentials/src/binary-to-text.ts
@@ -149,7 +149,7 @@ const execute: OperationExecuteExport = (request) => {
     ))
 
     // Transform unit size (encode)
-    const encodedUnits = transformUnitSize(units, inUnitSize, outUnitSize)
+    const encodedUnits = transformUnitSize(units, inUnitSize, outUnitSize, true)
     const encodedCodePoints = encodedUnits.map(unit => alphabet[unit])
 
     // Apply padding
@@ -195,7 +195,7 @@ const execute: OperationExecuteExport = (request) => {
     encodedUnits = encodedUnits.slice(0, j)
 
     // Transform unit size (decode)
-    const units = transformUnitSize(encodedUnits, outUnitSize, inUnitSize)
+    const units = transformUnitSize(encodedUnits, inUnitSize, outUnitSize, false)
     const buffer = Uint8Array.from(units).buffer
 
     // Add an issue if foreign characters were encountered

--- a/packages/app-web/src/slices/blueprint/index.ts
+++ b/packages/app-web/src/slices/blueprint/index.ts
@@ -101,7 +101,7 @@ export const blueprintSlice = createSlice({
       programId?: BlueprintNodeId
     }>) => {
       const programId = payload.programId ?? state.selectedNodeIds[0]
-      if (programId !== undefined) {
+      if (programId !== undefined && getNode(state, programId).type === 'program') {
         state.activeProgramId = programId
         state.selectedNodeIds = []
       }


### PR DESCRIPTION
I ~~accidentally~~ based this on #41, if that is not accepted this should be cherry picked to only commit `947f0a9`.
Only changes `packages/app-web/src/slices/blueprint/index.ts`

The node type for the enterProgram shortcut (enter/cmd+down) was not checked, because `programId` was assumed to be undefined for non-program nodes. It is actually also used by control nodes. This commit adds a double check that you actually use the shortcut on a program node.

<img width="409" alt="console error" src="https://github.com/user-attachments/assets/428fe748-e126-49e3-9e39-8ac0e4a685eb">

In this example I show that entering a program with keyboard shortcut `meta+down` is possible, but this also tries to enter the non-existent program defined by the control node `programId`. You can see the program crashes because everything disappears, “everything” being the node and the “explore” message.

https://github.com/user-attachments/assets/f3e96c1f-15dd-4a96-851f-6f4ca06366bb

